### PR TITLE
fix: user connections was not completely deleted when unbinding

### DIFF
--- a/src/main/java/run/halo/oauth/UserConnectionEndpoint.java
+++ b/src/main/java/run/halo/oauth/UserConnectionEndpoint.java
@@ -79,6 +79,7 @@ public class UserConnectionEndpoint implements CustomEndpoint {
     Mono<ServerResponse> disconnect(ServerRequest request) {
         String registrationId = request.pathVariable("registrationId");
         return userConnectionService.removeConnection(registrationId)
+            .collectList()
             .flatMap(result -> ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(result)

--- a/src/main/java/run/halo/oauth/UserConnectionService.java
+++ b/src/main/java/run/halo/oauth/UserConnectionService.java
@@ -1,6 +1,7 @@
 package run.halo.oauth;
 
 import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.UserConnection;
 
@@ -24,5 +25,5 @@ public interface UserConnectionService {
         OAuth2LoginAuthenticationToken authentication);
 
 
-    Mono<UserConnection> removeConnection(String registrationId);
+    Flux<UserConnection> removeConnection(String registrationId);
 }


### PR DESCRIPTION
### What this PR does?
修复用户解绑时 UserConnection 数据没有完全删除的问题 

how to test it?
绑定账号并解绑查看关联的 userconnections 是否被删除
```
curl -u 'your-username:your-password' http://127.0.0.1:8090/apis/auth.halo.run/v1alpha1/userconnections | jq  -r '.'
```
Fixes #8 

```release-note
修复用户解绑时 UserConnection 数据没有被完全删除的问题 
```