### PR TITLE
chore: release 1.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-SNAPSHOT
+version=1.0.1-SNAPSHOT

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,6 @@ metadata:
   name: plugin-oauth2
 spec:
   enabled: true
-  version: 1.0.1
   requires: ">=2.4.0"
   author:
     name: Halo OSS Team

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: plugin-oauth2
 spec:
   enabled: true
-  version: 1.0.0
+  version: 1.0.1
   requires: ">=2.4.0"
   author:
     name: Halo OSS Team


### PR DESCRIPTION
发布 1.0.1，修复认证方式描述不正确的问题。

```release-note
None 
```