### PR TITLE
chore: release 1.0.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1-SNAPSHOT
+version=1.0.2-SNAPSHOT

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,6 +4,7 @@ metadata:
   name: plugin-oauth2
 spec:
   enabled: true
+  version: "1.0.2"
   requires: ">=2.4.0"
   author:
     name: Halo OSS Team


### PR DESCRIPTION
发布 1.0.2，修复 1.0.1 发布的构建问题（删除了 version 字段，但 Gradle 插件未自动向 plugin.yaml 添加 version 字段）。

```release-note
None
```