### PR TITLE
chore: bump version to 1.0.4-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2-SNAPSHOT
+version=1.0.4-SNAPSHOT


### PR DESCRIPTION
### What this PR does?
bump version to 1.0.4-SNAPSHOT

```release-note
None
```