### PR TITLE
refactor: enhance OAuth2 error handling by adding user-friendly exception messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,4 +30,5 @@ test {
 
 halo {
     version = '2.17'
+    debug = true
 }


### PR DESCRIPTION
### What this PR does?
/kind improvement

增加友好的异常日志以便在 OAuth2 身份验证失败时向用户提供清晰的反馈，如不匹配的重定向URL

示例：
```shell
2024-08-02T14:56:24.357+08:00 ERROR 7 --- [or-http-epoll-3] r.halo.oauth.Oauth2LoginConfiguration    : An error occurred while attempting to oauth2 authenticate: 
error: redirect_uri_mismatch
error_description: The redirect_uri MUST match the registered callback URL for this application.
error_uri: https://docs.github.com/apps/managing-oauth-apps/troubleshooting-authorization-request-errors/#redirect-uri-mismatch


org.springframework.security.oauth2.core.OAuth2AuthenticationException: [authorization_request_not_found] 
	at run.halo.oauth.Oauth2LoginConfiguration$Initializer.lambda$getAuthenticationConverter$0(Oauth2LoginConfiguration.java:238) ~[na:na]
	at reactor.core.publisher.Mono.lambda$onErrorMap$27(Mono.java:3840) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.Mono.lambda$onErrorResume$29(Mono.java:3930) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.M
onoFlatMap$FlatMapMain.onError(MonoFlatMap.java:180) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onError(Operators.java:2236) ~[reactor-core-3.6.7.jar:3.6.7]
error: redirect_uri_mismatch

	at reactor.core.publisher.Operators.error(Operators.java:198) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.MonoError.subscribe(MonoError.java:53) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:53) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4568) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onComplete(FluxSwitchIfEmpty.java:82) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onComplete(MonoFlatMap.java:189) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.FluxFilter$FilterSubscriber.onComplete(FluxFilter.java:166) ~[reactor-core-3.6.7.jar:3.6.7]
	at reactor.core.publisher.FluxMap$MapConditionalSubscribe
r.onComplete(FluxMap.java:275) ~[reactor-core-3.6.7.jar:3.6.7]
```
```release-note
增加友好的异常日志以便在 OAuth2 身份验证失败时向用户提供清晰的反馈
```