### PR TITLE
Fix the problem of NoSuchMethod error of auth provider

### DIFF
--- a/src/main/java/run/halo/oauth/OauthClientRegistrationRepository.java
+++ b/src/main/java/run/halo/oauth/OauthClientRegistrationRepository.java
@@ -3,9 +3,10 @@ package run.halo.oauth;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
@@ -160,7 +161,10 @@ public class OauthClientRegistrationRepository implements ReactiveClientRegistra
         return client.fetch(ConfigMap.class, SystemSetting.SYSTEM_CONFIG)
             .map(configMap -> {
                 var authProvider = getAuthProvider(configMap);
-                return authProvider.getEnabled();
+                return authProvider.getStates().stream()
+                    .filter(SystemSetting.AuthProviderState::isEnabled)
+                    .map(SystemSetting.AuthProviderState::getName)
+                    .collect(Collectors.toSet());
             })
             .defaultIfEmpty(Set.of());
     }
@@ -180,8 +184,8 @@ public class OauthClientRegistrationRepository implements ReactiveClientRegistra
             authProvider = JsonUtils.jsonToObject(providerGroup, SystemSetting.AuthProvider.class);
         }
 
-        if (authProvider.getEnabled() == null) {
-            authProvider.setEnabled(new HashSet<>());
+        if (authProvider.getStates() == null) {
+            authProvider.setStates(List.of());
         }
         return authProvider;
     }

--- a/src/test/java/run/halo/oauth/OauthClientRegistrationRepositoryTest.java
+++ b/src/test/java/run/halo/oauth/OauthClientRegistrationRepositoryTest.java
@@ -53,7 +53,9 @@ class OauthClientRegistrationRepositoryTest {
             .thenReturn(Mono.just(authProvider));
         ConfigMap systemConfig = new ConfigMap();
         systemConfig.setData(Map.of(SystemSetting.AuthProvider.GROUP,
-            "{\"enabled\":[\"github\"]}"));
+            """
+                {"states":[{"name":"github", "enabled":true}]}\
+                """));
         when(client.fetch(eq(ConfigMap.class), eq(SystemSetting.SYSTEM_CONFIG)))
             .thenReturn(Mono.just(systemConfig));
 


### PR DESCRIPTION
Current plugin cannot work due to removal of method `run.halo.app.infra.SystemSetting.AuthProvider#enabled` in Halo 2.20.0. This PR fixes it by using new alternative method `run.halo.app.infra.SystemSetting.AuthProvider#states`.

/kind bug

```release-note
修复无法在 Halo 2.20.0 中正常登录的问题
```