### PR TITLE
Resolve baseUrl in redirect URI with external URL

### DIFF
--- a/src/main/java/run/halo/oauth/Oauth2LoginConfiguration.java
+++ b/src/main/java/run/halo/oauth/Oauth2LoginConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.server.savedrequest.WebSessionServerRequ
 import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.security.LoginHandlerEnhancer;
 
 /**
@@ -38,12 +39,16 @@ public class Oauth2LoginConfiguration {
 
     private final LoginHandlerEnhancer loginHandlerEnhancer;
 
+    private final ExternalUrlSupplier externalUrlSupplier;
+
     private ServerRequestCache requestCache = new WebSessionServerRequestCache();
 
     public Oauth2LoginConfiguration(ReactiveExtensionClient extensionClient,
-        LoginHandlerEnhancer loginHandlerEnhancer) {
+        LoginHandlerEnhancer loginHandlerEnhancer,
+        ExternalUrlSupplier externalUrlSupplier) {
         this.extensionClient = extensionClient;
         this.loginHandlerEnhancer = loginHandlerEnhancer;
+        this.externalUrlSupplier = externalUrlSupplier;
 
         Initializer initializer = new Initializer();
         this.authenticationMatcher = initializer.getAuthenticationMatcher();
@@ -69,7 +74,7 @@ public class Oauth2LoginConfiguration {
         }
 
         ReactiveClientRegistrationRepository getClientRegistrationRepository() {
-            return new OauthClientRegistrationRepository(extensionClient);
+            return new OauthClientRegistrationRepository(extensionClient, externalUrlSupplier);
         }
 
         ServerOAuth2AuthorizedClientRepository getAuthorizedClientRepository() {

--- a/src/test/java/run/halo/oauth/Oauth2LoginConfigurationTest.java
+++ b/src/test/java/run/halo/oauth/Oauth2LoginConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.security.LoginHandlerEnhancer;
 
 /**
@@ -19,8 +20,9 @@ class Oauth2LoginConfigurationTest {
     void constructor() {
         ReactiveExtensionClient extensionClient = mock(ReactiveExtensionClient.class);
         var loginHandlerEnhancer = mock(LoginHandlerEnhancer.class);
+        var externalUrlSupplier = mock(ExternalUrlSupplier.class);
         Oauth2LoginConfiguration oauth2LoginConfiguration =
-            new Oauth2LoginConfiguration(extensionClient, loginHandlerEnhancer);
+            new Oauth2LoginConfiguration(extensionClient, loginHandlerEnhancer, externalUrlSupplier);
         assertNotNull(oauth2LoginConfiguration);
     }
 


### PR DESCRIPTION
This PR resolves baseUrl in redirect URI `{baseUrl}/{action}/oauth2/code/{registrationId}` with external URL instead of current request. This will resolve the problems caused by reverse proxy server or CDN.

/kind improvement

Fixes #73 

```release-note
解决回调地址配置正确但实际跳转时出错的问题
```