### PR TITLE
Add support for issuerUri/jwkSetUri and multiple scopes for SSO OAuth2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.5.1
+version=1.7.1

--- a/src/main/resources/extensions/setting.yaml
+++ b/src/main/resources/extensions/setting.yaml
@@ -60,3 +60,11 @@ spec:
           label: "UserName Attribute"
           validation: required:trim
           value: "name"
+        - $formkit: text
+          name: issuerUri
+          label: "Issuer URI"
+          help: "The Issuer Identifier of the OpenID Connect Provider."
+        - $formkit: text
+          name: jwkSetUri
+          label: "JWK Set URI"
+          help: "The URL to the JWK Set (KEYS) of the OpenID Connect Provider."


### PR DESCRIPTION
1. **支持 `issuerUri` 和 `jwkSetUri`**：新增了可选配置项，允许手动指定发行人标识符（Issuer Identifier）和 JWK Set URI。这在自动发现受限或需要特定端点时非常有用。
2. **支持多 Scope**：允许 `scopes` 配置接受以空格或逗号分隔的多个值（例如 `openid profile email` 或 `openid,profile,email`），这些值将被正确解析并在授权请求中发送。

Fixes https://github.com/halo-sigs/plugin-oauth2/issues/79
Fixes https://github.com/halo-sigs/plugin-oauth2/issues/88

```release-note
自定义 SSO 支持配置 issuerUri、jwkSetUri 以及多个 scope
```